### PR TITLE
Fix typo in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
 To run the demo with the dev model and create a public link:
 
 ```bash
-python -m demo_gr.py --name flux-dev --share
+python demo_gr.py --name flux-dev --share
 ```
 
 ## Diffusers integration


### PR DESCRIPTION
Without the change in this PR, users get:

```
(.venv) ubuntu@192-222-52-107:~/flux$ python -m demo_gr.py --name flux-dev --share
/home/ubuntu/flux/.venv/bin/python: Error while finding module specification for 'demo_gr.py' (ModuleNotFoundError: __path__ attribute not found on 'demo_gr' while trying to find 'demo_gr.py'). Try using 'demo_gr' instead of 'demo_gr.py' as the module name.
```