### PR TITLE
Included gitignore to remove setup step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+flux.egg-info/
+src/flux/_version.py


### PR DESCRIPTION
To remove the need of adding the gitignore to ignore changes for `_version.py`, the `.venv` and others.