### PR TITLE
cli: Fix output filename selection for >10 images

### DIFF
--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -148,9 +148,14 @@ def main(
         os.makedirs(output_dir)
         idx = 0
     else:
-        fns = [fn for fn in iglob(output_name.format(idx="*")) if re.search(r"img_[0-9]\.jpg$", fn)]
-        if len(fns) > 0:
-            idx = max(int(fn.split("_")[-1].split(".")[0]) for fn in fns) + 1
+        old_indices = [
+            int(m.group(1))
+            for fn in iglob(output_name.format(idx="*"))
+            if (m := re.search(r"img_(0|[1-9][0-9]*)\.jpg$", fn))
+        ]
+
+        if old_indices:
+            idx = max(old_indices) + 1
         else:
             idx = 0
 


### PR DESCRIPTION
Images by default are placed in output/img_N.jpg where N is a monotonically increased index.

There's a logic bug in the code, however, where it neglects filenames that have more than one digit as an index.

This commit changes the logic to handle multi-digit filenames, and also adds an optimization to avoid reparsing the filename to obtain the index back out later, by reusing the results of the initial regex search.