### PR TITLE
Fix CLI time measurement

### DIFF
--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -215,6 +215,9 @@ def main(
         x = unpack(x.float(), opts.height, opts.width)
         with torch.autocast(device_type=torch_device.type, dtype=torch.bfloat16):
             x = ae.decode(x)
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         t1 = time.perf_counter()
 
         fn = output_name.format(idx=idx)


### PR DESCRIPTION
Torch CUDA operations are [async by default](https://pytorch.org/docs/stable/notes/cuda.html#asynchronous-execution). 

The original code stops the clock as soon as torch finishes issuing GPU operations, but the results wouldn't actually be ready at that point, so it's an underestimate. We need an explicit sync to correctly time end-to-end execution of the model.

Testing on flux-dev, 1024x768 resolution, 28-steps, on H100 SXM.
Before: 5520ms
After: 6040ms

Exact delta depends on how much the CPU is running ahead of the GPU, which varies significantly across systems. This also means that timings should be more stable after this change.

credit to @donglinz for finding this bug!