### PR TITLE
CLI: `/n` is for steps, not seeds

### DIFF
--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -80,7 +80,7 @@ def parse_prompt(options: SamplingOptions) -> SamplingOptions | None:
                 continue
             _, steps = prompt.split()
             options.num_steps = int(steps)
-            print(f"Setting seed to {options.num_steps}")
+            print(f"Setting number of steps to {options.num_steps}")
         elif prompt.startswith("/q"):
             print("Quitting")
             return None


### PR DESCRIPTION
This fixes a CLI issue where `/n` reports changing the seed number

<img width="856" alt="Screenshot 2024-10-02 at 16 59 49" src="https://github.com/user-attachments/assets/ca1b2bfb-f5a0-4a7e-8081-f12dff096149">
