### PR TITLE
Remove unused import and extraneous `f` prefix

### DIFF
--- a/demo_gr.py
+++ b/demo_gr.py
@@ -1,6 +1,5 @@
 import os
 import time
-from io import BytesIO
 import uuid
 
 import torch

--- a/src/flux/api.py
+++ b/src/flux/api.py
@@ -100,7 +100,7 @@ class ImageRequest:
 
             if name == "flux.1-dev":
                 if interval is not None:
-                    raise ValueError(f"Interval is not supported for flux.1-dev")
+                    raise ValueError("Interval is not supported for flux.1-dev")
             if name == "flux.1.1-pro":
                 if (
                     interval is not None


### PR DESCRIPTION
- Remove unused import: `io.BytesIO`
- Remove extraneous `f` prefix