### PR TITLE
fix typo in  cli_fill.py when offload is True

### DIFF
--- a/src/flux/cli_fill.py
+++ b/src/flux/cli_fill.py
@@ -271,7 +271,7 @@ def main(
         )
         opts.seed = None
         if offload:
-            t5, clip, ae = t5.to(torch_device), clip.to(torch_device), ae.to(torch.device)
+            t5, clip, ae = t5.to(torch_device), clip.to(torch_device), ae.to(torch_device)
         inp = prepare_fill(
             t5,
             clip,


### PR DESCRIPTION
solve this error when offload is set to True:

> TypeError: to() received an invalid combination of arguments - got (type), but expected one of:
>  * (torch.device device = None, torch.dtype dtype = None, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)
>  * (torch.dtype dtype, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)
>  * (Tensor tensor, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)