### PR TITLE
fix: add tensorrt to all dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ tensorrt = [
   "polygraphy ~= 0.49.9",
 ]
 all = [
+  "flux[tensorrt]",
   "flux[gradio]",
   "flux[streamlit]",
   "flux[torch]",


### PR DESCRIPTION
Users expect `all` to truly include all. Also, without this fix, `demo_gr.py` for example, won't work:

```
(.venv) ubuntu@129-146-111-239:~/flux$ python3 demo_gr.py --name flux-schnell --share
Traceback (most recent call last):
  File "/home/ubuntu/flux/demo_gr.py", line 12, in <module>
    from flux.cli import SamplingOptions
  File "/home/ubuntu/flux/src/flux/cli.py", line 8, in <module>
    from cuda import cudart
ModuleNotFoundError: No module named 'cuda'
```