### PR TITLE
Add torch.compile option to CLI

### DIFF
--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -131,6 +131,7 @@ def main(
         loop: start an interactive session and sample multiple times
         guidance: guidance value used for guidance distillation
         add_sampling_metadata: Add the prompt to the image Exif metadata
+        compile: use torch.compile for optimized inference
         trt: use TensorRT backend for optimized inference
         kwargs: additional arguments for TensorRT support
     """
@@ -178,7 +179,12 @@ def main(
     model = load_flow_model(name, device="cpu" if offload else torch_device)
     ae = load_ae(name, device="cpu" if offload else torch_device)
 
-    if trt:
+    if compile:
+        t5 = torch.compile(t5)
+        clip = torch.compile(clip)
+        model = torch.compile(model)
+        ae.decode = torch.compile(ae.decode)
+    elif trt:
         # offload to CPU to save memory
         ae = ae.cpu()
         model = model.cpu()


### PR DESCRIPTION
`torch.compile` is very good - it compiles very fast (16 secs), and provides 60% speedup vs. eager mode (measured on H100, other gpus should have a lot of speedups too).

TensorRT takes a very long time to compile and the UX is not great, and it doesn't support LoRA. `torch.compile` compile time is very fast, and it supports LoRA (or any other kinds of model changes that people want to make).