### PR TITLE
Make ruff an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,15 @@ dependencies = [
   "protobuf",
   "requests",
   "invisible-watermark",
-  "ruff == 0.6.8",
 ]
 
 [project.optional-dependencies]
 torch = [
   "torch == 2.5.1",
   "torchvision",
+]
+lint = [
+  "ruff == 0.6.8",
 ]
 streamlit = [
   "streamlit",


### PR DESCRIPTION
Hi :wave:

First of all, thank you for open-sourcing Flux! I am having issues installing `flux` using `pip` due to `ruff` being included in the mandatory dependencies with a fixed version. This PR makes `ruff` an optional dependency.
