### PR TITLE
fix: resolve circular import by renaming math.py

### DIFF
--- a/src/flux/flux_math.py
+++ b/src/flux/flux_math.py
@@ -1,0 +1,30 @@
+import torch
+from einops import rearrange
+from torch import Tensor
+
+
+def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor) -> Tensor:
+    q, k = apply_rope(q, k, pe)
+
+    x = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    x = rearrange(x, "B H L D -> B L (H D)")
+
+    return x
+
+
+def rope(pos: Tensor, dim: int, theta: int) -> Tensor:
+    assert dim % 2 == 0
+    scale = torch.arange(0, dim, 2, dtype=pos.dtype, device=pos.device) / dim
+    omega = 1.0 / (theta**scale)
+    out = torch.einsum("...n,d->...nd", pos, omega)
+    out = torch.stack([torch.cos(out), -torch.sin(out), torch.sin(out), torch.cos(out)], dim=-1)
+    out = rearrange(out, "b n d (i j) -> b n d i j", i=2, j=2)
+    return out.float()
+
+
+def apply_rope(xq: Tensor, xk: Tensor, freqs_cis: Tensor) -> tuple[Tensor, Tensor]:
+    xq_ = xq.float().reshape(*xq.shape[:-1], -1, 1, 2)
+    xk_ = xk.float().reshape(*xk.shape[:-1], -1, 1, 2)
+    xq_out = freqs_cis[..., 0] * xq_[..., 0] + freqs_cis[..., 1] * xq_[..., 1]
+    xk_out = freqs_cis[..., 0] * xk_[..., 0] + freqs_cis[..., 1] * xk_[..., 1]
+    return xq_out.reshape(*xq.shape).type_as(xq), xk_out.reshape(*xk.shape).type_as(xk)

--- a/src/flux/modules/layers.py
+++ b/src/flux/modules/layers.py
@@ -5,7 +5,7 @@ import torch
 from einops import rearrange
 from torch import Tensor, nn
 
-from flux.math import attention, rope
+from flux.flux_math import attention, rope
 
 
 class EmbedND(nn.Module):


### PR DESCRIPTION
### Issue Description  
**Problem**: When executing `python -m flux.cli --prompt="A beautiful forest"`, the following error occurs:  

<img width="1376" alt="Screenshot 2025-04-07 at 22 51 52" src="https://github.com/user-attachments/assets/1e496d17-109f-455b-9e4d-24f9c35b2fbd" />

```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jaylaw/flux/src/flux/cli.py", line 7, in <module>
    import torch
  File "/Users/jaylaw/flux/.venv/lib/python3.13/site-packages/torch/__init__.py", line 18, in <module>
    import math
  File "/Users/jaylaw/flux/src/flux/math.py", line 3, in <module>
    from torch import Tensor
ImportError: cannot import name 'Tensor' from partially initialized module 'torch' (most likely due to a circular import) (/Users/jaylaw/flux/.venv/lib/python3.13/site-packages/torch/__init__.py)
```

**Cause**:  
1. **Direct Cause**:  
   • `torch/__init__.py` attempts to import the built-in `math` module during initialization.  
   • The project’s custom `flux/math.py` simultaneously tries to import `Tensor` from `torch`, creating a circular dependency.  

2. **Root Cause**:  
   • Naming conflict: `flux/math.py` shadows Python’s built-in `math` module. When `torch` imports `math`, Python incorrectly loads `flux/math.py` instead of the standard library.  

### Solution  
1. Rename `math.py` to `flux_math.py` to avoid naming collisions.  
2. Update all references to the renamed file (There is only one: `src/flux/models/layers.py`).  

### Validation  
• Local test: Executing `python -m flux.cli --prompt="A beautiful forest"` resolves the original error (new issues unrelated to this fix may arise).  
<img width="1376" alt="Screenshot 2025-04-07 at 23 09 16" src="https://github.com/user-attachments/assets/aab9f1e8-63bf-487e-b2a0-179275e54ad2" />
